### PR TITLE
Snappy should be able to decompress an empty binary

### DIFF
--- a/c_src/snappy_nif.cc
+++ b/c_src/snappy_nif.cc
@@ -167,6 +167,14 @@ snappy_decompress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
 
+    // Check that the binary is not empty
+    if(bin.size == 0) {
+        // Snappy library cannot decompress an empty binary - although
+        // it will unfortunately let you compress one. If an empty binary
+        // has been passed - send an empty binary back.
+        return make_ok(env, enif_make_binary(env,&ret));
+    }
+
     try {
         if(!snappy::GetUncompressedLength(SC_PTR(bin.data), bin.size, &len)) {
             return make_error(env, "data_not_compressed");

--- a/c_src/snappy_nif.cc
+++ b/c_src/snappy_nif.cc
@@ -138,10 +138,6 @@ ERL_NIF_TERM
 snappy_compress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ErlNifBinary input;
-    ErlNifBinary empty;
-
-    // init empty;
-    memset(&empty,0,sizeof(ErlNifBinary));
 
     if(!enif_inspect_iolist_as_binary(env, argv[0], &input)) {
         return enif_make_badarg(env);
@@ -151,6 +147,9 @@ snappy_compress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     // Snappy will do this in any case, so might as well skip the
     // overhead...
     if(input.size == 0) {
+        ErlNifBinary empty;
+        // init empty;
+        memset(&empty,0,sizeof(ErlNifBinary));
         return make_ok(env, enif_make_binary(env,&empty));
      }
 
@@ -174,9 +173,6 @@ snappy_decompress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ErlNifBinary ret;
     size_t len;
 
-    // init ret;
-    memset(&ret,0,sizeof(ErlNifBinary));
-
     if(!enif_inspect_iolist_as_binary(env, argv[0], &bin)) {
         return enif_make_badarg(env);
     }
@@ -186,6 +182,7 @@ snappy_decompress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
         // Snappy library cannot decompress an empty binary - although
         // it will unfortunately let you compress one. If an empty binary
         // has been passed - send an empty binary back.
+        memset(&ret,0,sizeof(ErlNifBinary));
         return make_ok(env, enif_make_binary(env,&ret));
     }
 

--- a/c_src/snappy_nif.cc
+++ b/c_src/snappy_nif.cc
@@ -138,10 +138,21 @@ ERL_NIF_TERM
 snappy_compress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     ErlNifBinary input;
+    ErlNifBinary empty;
+
+    // init empty;
+    memset(&empty,0,sizeof(ErlNifBinary));
 
     if(!enif_inspect_iolist_as_binary(env, argv[0], &input)) {
         return enif_make_badarg(env);
     }
+
+    // If empty binary has been provided, return an empty binary.
+    // Snappy will do this in any case, so might as well skip the
+    // overhead...
+    if(input.size == 0) {
+        return make_ok(env, enif_make_binary(env,&empty));
+     }
 
     try {
         snappy::ByteArraySource source(SC_PTR(input.data), input.size);
@@ -162,6 +173,9 @@ snappy_decompress_erl(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     ErlNifBinary bin;
     ErlNifBinary ret;
     size_t len;
+
+    // init ret;
+    memset(&ret,0,sizeof(ErlNifBinary));
 
     if(!enif_inspect_iolist_as_binary(env, argv[0], &bin)) {
         return enif_make_badarg(env);

--- a/test/snappy_tests.erl
+++ b/test/snappy_tests.erl
@@ -72,3 +72,9 @@ decompression() ->
     ?assertEqual({ok, BigData}, snappy:decompress(Compressed3)),
     ok.
 
+can_compress_and_decompress_empty_lists_test() ->
+    % Try to compress an empty list...
+    {ok, Compressed} = snappy:compress([]),
+    % Try to decompress the result of the compression...
+    {ok, Decompressed} = snappy:decompress(Compressed),
+    ok.

--- a/test/snappy_tests.erl
+++ b/test/snappy_tests.erl
@@ -72,9 +72,9 @@ decompression() ->
     ?assertEqual({ok, BigData}, snappy:decompress(Compressed3)),
     ok.
 
-can_compress_and_decompress_empty_lists_test() ->
+can_compress_and_decompress_empty_binary_test() ->
     % Try to compress an empty list...
-    {ok, Compressed} = snappy:compress([]),
+    {ok, Compressed} = snappy:compress(<<>>),
     % Try to decompress the result of the compression...
     {ok, Decompressed} = snappy:decompress(Compressed),
     ok.

--- a/test/snappy_tests.erl
+++ b/test/snappy_tests.erl
@@ -72,9 +72,36 @@ decompression() ->
     ?assertEqual({ok, BigData}, snappy:decompress(Compressed3)),
     ok.
 
+check_double_decompress_doesnt_cause_segault_test() ->
+    % Try to decompress an empty binary
+    ?assertMatch({ok,<<>>}, snappy:decompress(<<>>)),
+    % And once more...
+    ?assertMatch({ok,<<>>}, snappy:decompress(<<>>)),
+    ok.
+
+check_double_compress_doesnt_cause_segault_test() ->
+    % Try to compress an empty binary
+    ?assertMatch({ok,<<>>},snappy:compress(<<>>)),
+    % And once more...
+    ?assertMatch({ok,<<>>},snappy:compress(<<>>)),
+    ok.
+
 can_compress_and_decompress_empty_binary_test() ->
-    % Try to compress an empty list...
+    % Try to compress an empty binary...
     {ok, Compressed} = snappy:compress(<<>>),
     % Try to decompress the result of the compression...
     {ok, Decompressed} = snappy:decompress(Compressed),
+    ok.
+
+can_compress_an_empty_binary_test() ->
+    % Try to compress an empty binary...
+    {ok, Compressed} = snappy:compress(<<>>),
+    % Check an empty binary was returned
+    ?assertMatch(Compressed,<<>>),
+    ok.
+
+can_decompress_an_empty_binary_test() ->
+    % Try to decompress an empty binary
+    {ok, Decompressed} = snappy:decompress(<<>>),
+    ?assertMatch(Decompressed,<<>>),
     ok.


### PR DESCRIPTION
Hi guys,

A year ago I raised an issue (https://github.com/fdmanana/snappy-erlang-nif/issues/6) discussing the case where the Snappy library will accept an empty binary and return:

```
{ok, <<>>}
```

but if you try to decompress an empty binary, it will throw an error. This is a big problem if you're writing data to disk and running everything through Snappy because you expect that everything you read back will be decompressable. 

Admittedly it can be argued whether or not an empty binary *is* valid for compression. I'd say it probably isn't but given that people might already be using it with this behaviour, I wanted a backwards compatible change.

This change will return an empty binary:

```
{ok, <<>>} = snappy:decompress(<<>>).
```

Whilst I was at it, I added some code to short cut the compression cycle if compression is attempt on an empty binary. The same value is returned, just it doesn't go through the compression engine itself.

I'm happy to cancel this pull request and add code to make attempting to compress an empty binary an error condition.

Cheers,

Pete