### PR TITLE
Add erlang 19 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R13B04|R14|R15|R16|17|18"}.
+{require_otp_vsn, "R13B04|R14|R15|R16|17|18|19"}.
 
 {erl_opts, [debug_info, warn_unused_vars, warn_shadow_vars, warn_unused_import]}.
 {port_env, [


### PR DESCRIPTION
OTP 19 was recently released and it would be great if this library worked with it.

Compiling and tests work so I don't see a reason why not to allow it.