### PR TITLE
Change exit/1 to nif_error/1

### DIFF
--- a/src/snappy.erl
+++ b/src/snappy.erl
@@ -41,16 +41,16 @@ init() ->
 
 
 compress(_IoList) ->
-    exit(snappy_nif_not_loaded).
+    erlang:nif_error(snappy_nif_not_loaded).
 
 
 decompress(_IoList) ->
-    exit(snappy_nif_not_loaded).
+    erlang:nif_error(snappy_nif_not_loaded).
 
 
 uncompressed_length(_IoList) ->
-    exit(snappy_nif_not_loaded).
+    erlang:nif_error(snappy_nif_not_loaded).
 
 
 is_valid(_IoList) ->
-    exit(snappy_nif_not_loaded).
+    erlang:nif_error(snappy_nif_not_loaded).


### PR DESCRIPTION
Calling `exit/1` makes dialyzer think that the various functions here have no local return. `erlang:nif_error/1` works the same way, but dialyzer won't complain about no local return.

http://erlang.org/doc/man/erlang.html#nif_error-1